### PR TITLE
Best day

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,9 +24,15 @@ class Item < ApplicationRecord
   end
 
   def best_day
-require 'pry'; binding.pry
-    invoices.group('DATE(created_at)').count
-    .sum()
-    .limit(1)
+    invoices
+      .select("DATE_TRUNC('day', invoices.created_at) as created_at, SUM(invoice_items.quantity * invoice_items.unit_price) as sales")
+      .group(:created_at)
+      .order(sales: :desc, created_at: :desc)
+      .limit(1)
+      .first
+  end
+
+  def revenue
+    invoice_items.sum('quantity * unit_price')
   end
 end

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -5,8 +5,8 @@
   <ol>
     <% @merchant.top_five_items.each do |item| %>
     <div id="popular-<%= item.id %>">
-          <li><%= link_to item.name, merchant_item_path(id: item.id) %> Revenue: <%= number_to_currency(item.revenue).to_f / 100 %></li>
-          <p>Top selling date for <%= item.name %> was <%= item.best_day %></p>
+          <li><%= link_to item.name, merchant_item_path(id: item.id) %> Revenue: <%= number_to_currency(item.revenue / 100) %></li>
+          <p>Top selling date for <%= item.name %> was <%= item.best_day.created_at_short_format %></p>
     </div>
     <% end %>
   </ol>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -237,8 +237,24 @@ RSpec.describe 'merchants items index page' do
     end
 # 7 6 5 4 3
     it 'top items best day' do
-      within("#popular-#{@item1.id}") do
-        save_and_open_page
+      save_and_open_page
+      within("#popular-#{@item7.id}") do
+        expect(page).to have_content("Top selling date for #{@item7.name} was #{@invoice14.created_at_short_format}")
+      end
+
+      within("#popular-#{@item6.id}") do
+        expect(page).to have_content("Top selling date for #{@item6.name} was #{@invoice12.created_at_short_format}")
+      end
+
+      within("#popular-#{@item5.id}") do
+        expect(page).to have_content("Top selling date for #{@item5.name} was #{@invoice14.created_at_short_format}")
+      end
+
+      within("#popular-#{@item4.id}") do
+        expect(page).to have_content("Top selling date for #{@item4.name} was #{@invoice8.created_at_short_format}")
+      end
+
+      within("#popular-#{@item3.id}") do
         expect(page).to have_content("Top selling date for #{@item3.name} was #{@invoice6.created_at_short_format}")
       end
     end


### PR DESCRIPTION
COMPLETED
- best day method
- revenue method

UPDATED
- merchant items index view
  - `number_to_currency(item.revenue / 100)`
  - `item.best_day.created_at_short_format`
- added four more assertions to top items best day test

TODO:
- model coverage @ 98.93%
- add assertions for revenue to top items best day test
- wake Khoi up for check-in